### PR TITLE
fixes NameError for CookieOverflow

### DIFF
--- a/lib/encrypted-cookies/encrypted_cookie_jar.rb
+++ b/lib/encrypted-cookies/encrypted_cookie_jar.rb
@@ -29,7 +29,7 @@ module EncryptedCookies
         options = { :value => @encrypter.encrypt_and_sign(options) }
       end
 
-      raise CookieOverflow if options[:value].size > MAX_COOKIE_SIZE
+      raise ActionDispatch::Cookies::CookieOverflow if options[:value].size > MAX_COOKIE_SIZE
       @parent_jar[key] = options
     end
 


### PR DESCRIPTION
This fixes the following exception:

```
uninitialized constant EncryptedCookies::EncryptedCookieJar::CookieOverflow
```
